### PR TITLE
Fix Android 4.1-4.3 WebView source baseUrl bug

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -88,7 +88,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   protected static final String REACT_CLASS = "RCTWebView";
 
   protected static final String HTML_ENCODING = "UTF-8";
-  protected static final String HTML_MIME_TYPE = "text/html; charset=utf-8";
+  protected static final String HTML_MIME_TYPE = "text/html";
   protected static final String BRIDGE_NAME = "__REACT_WEB_VIEW_BRIDGE";
 
   protected static final String HTTP_METHOD_POST = "POST";


### PR DESCRIPTION
Resolves #11753. Android versions 4.1-4.3 don't understand the MIME type 'text/html; charset=utf-8' and default to 'text/plain' instead, rendering the content as an unparsed HTML string. Since the encoding is already set and passed separately, removing it from the MIME type has no negative effects.

The fix follows Android Doc on WebView.loadData() and WebView.loadDataWithBaseUrl():

https://developer.android.com/reference/android/webkit/WebView.html

The same fix has already been discussed, successfully tested and incorporated in NativeScript/NativeScript#1038.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
